### PR TITLE
Remove Param in favor of TextUnmarshaler

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -251,21 +251,18 @@ const (
 // using the appropriate method from the strconv package in the standard
 // library.
 //
-// Run also works with any type that implements the Param interface in the
-// github.com/ucarion/cli/param package:
+// Run also works with any type that implements TextUnmarshaler from the
+// encoding standard library package.
 //
-//  type Param interface {
-//      Set(string) error
-//  }
-//
-// Run will call Set on the zero value of your Param implementation, where the
-// string is the value to parse. If Set returns an error, then the string is
-// considered a bad argument.
+// Run will call TextUnmarshal on the zero value of your TextUnmarshal
+// implementation, where the text is the value to parse. If TextUnmarshal
+// returns an error, then the text is considered a bad argument.
 //
 // Furthermore, all of the types above are supported in slices or pointers. In
-// other words, if T is one of the types described previously (it is a Param or
-// is in the list of primitive types above), then []T and *T are supported as
-// well. This rule does not apply recursively; [][]T is not supported.
+// other words, if T is one of the types described previously (it is a
+// TextUnmarshaler or is in the list of primitive types above), then []T and *T
+// are supported as well. This rule does not apply recursively; [][]T is not
+// supported.
 //
 // Wrapping a type with a slice (that is, doing "[]T") indicates that the
 // argument can be passed multiple times. For trailing arguments, the type must

--- a/examples/customtype/main.go
+++ b/examples/customtype/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ucarion/cli"
+)
+
+type args struct {
+	Foo bytes `cli:"--foo"`
+}
+
+type bytes int
+
+func (b *bytes) UnmarshalText(text []byte) error {
+	s := string(text)
+
+	var base string
+	var factor int
+
+	switch {
+	case strings.HasSuffix(s, "KB"):
+		base = s[:len(s)-2]
+		factor = 1024
+	case strings.HasSuffix(s, "MB"):
+		base = s[:len(s)-2]
+		factor = 1024 * 1024
+	case strings.HasSuffix(s, "GB"):
+		base = s[:len(s)-2]
+		factor = 1024 * 1024 * 1024
+	case strings.HasSuffix(s, "TB"):
+		base = s[:len(s)-2]
+		factor = 1024 * 1024 * 1024 * 1024
+	case strings.HasSuffix(s, "B"):
+		base = s[:len(s)-1]
+		factor = 1
+	default:
+		return fmt.Errorf("missing units suffix (must be one of B, KB, MB, GB, TB): %s", s)
+	}
+
+	n, err := strconv.ParseInt(base, 0, 0)
+	if err != nil {
+		return err
+	}
+
+	*b = bytes(int(n) * factor)
+	return nil
+}
+
+func main() {
+	cli.Run(context.Background(), func(ctx context.Context, args args) error {
+		fmt.Printf("%#v\n", args)
+		return nil
+	})
+}

--- a/examples/ipparam/main.go
+++ b/examples/ipparam/main.go
@@ -3,27 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/url"
+	"net"
 
 	"github.com/ucarion/cli"
 )
 
 type args struct {
-	Foo urlParam `cli:"--foo"`
-}
-
-type urlParam struct {
-	Value url.URL
-}
-
-func (p *urlParam) Set(s string) error {
-	u, err := url.Parse(s)
-	if err != nil {
-		return err
-	}
-
-	p.Value = *u
-	return nil
+	Foo net.IP `cli:"--foo"`
 }
 
 func main() {

--- a/internal/argparser/argparser.go
+++ b/internal/argparser/argparser.go
@@ -5,12 +5,10 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/ucarion/cli/internal/didyoumean"
-
 	"github.com/ucarion/cli/internal/cmdtree"
-	"github.com/ucarion/cli/param"
-
 	"github.com/ucarion/cli/internal/command"
+	"github.com/ucarion/cli/internal/didyoumean"
+	"github.com/ucarion/cli/internal/param"
 )
 
 type Parser struct {
@@ -244,7 +242,7 @@ func getShortFlag(tree cmdtree.CommandTree, s string) (command.Flag, error) {
 func setConfigField(config reflect.Value, index []int, val string) error {
 	// cmdtree.New will have handled making sure all fields are param-friendly.
 	p, _ := param.New(config.FieldByIndex(index).Addr().Interface())
-	return p.Set(val)
+	return p.UnmarshalText([]byte(val))
 }
 
 func mayTakeValue(config reflect.Value, flag command.Flag) bool {

--- a/internal/cmdhelp/cmdhelp.go
+++ b/internal/cmdhelp/cmdhelp.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ucarion/cli/internal/cmdtree"
 	"github.com/ucarion/cli/internal/command"
-	"github.com/ucarion/cli/param"
+	"github.com/ucarion/cli/internal/param"
 )
 
 func Help(tree cmdtree.CommandTree, name []string) string {

--- a/internal/cmdman/cmdman.go
+++ b/internal/cmdman/cmdman.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ucarion/cli/internal/cmdtree"
 	"github.com/ucarion/cli/internal/command"
-	"github.com/ucarion/cli/param"
+	"github.com/ucarion/cli/internal/param"
 )
 
 func Man(tree cmdtree.CommandTree, name string) map[string]string {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/ucarion/cli/internal/param"
 	"github.com/ucarion/cli/internal/tagparse"
-	"github.com/ucarion/cli/param"
 )
 
 type Command struct {
@@ -68,7 +68,6 @@ func FromFunc(fn interface{}) (Command, ParentInfo, error) {
 }
 
 var (
-	paramType       = reflect.TypeOf((*param.Param)(nil)).Elem()
 	ctxType         = reflect.TypeOf((*context.Context)(nil)).Elem()
 	errType         = reflect.TypeOf((*error)(nil)).Elem()
 	stringType      = reflect.TypeOf("")

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -299,7 +299,7 @@ func TestFromType_GamutOfTypes(t *testing.T) {
 
 type customValue struct{}
 
-func (c customValue) Set(_ string) error {
+func (c customValue) UnmarshalText(_ []byte) error {
 	return nil
 }
 

--- a/internal/exectree/exectree_test.go
+++ b/internal/exectree/exectree_test.go
@@ -720,13 +720,13 @@ type customValue struct {
 	Value string
 }
 
-func (c *customValue) Set(s string) error {
-	c.Value = s
+func (c *customValue) UnmarshalText(s []byte) error {
+	c.Value = string(s)
 	return nil
 }
 
 type errParam struct{}
 
-func (p errParam) Set(_ string) error {
+func (p errParam) UnmarshalText(_ []byte) error {
 	return errors.New("dummy errParam err")
 }

--- a/internal/param/param_test.go
+++ b/internal/param/param_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/ucarion/cli/param"
+	"github.com/ucarion/cli/internal/param"
 )
 
 func TestMayMustTakeValue(t *testing.T) {
@@ -57,7 +57,7 @@ func TestNewBool(t *testing.T) {
 	var v bool
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("")
+		p.UnmarshalText([]byte(""))
 		assert.Equal(t, true, v)
 	}
 }
@@ -66,10 +66,10 @@ func TestNewInt(t *testing.T) {
 	var v int
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("-10")
+		p.UnmarshalText([]byte("-10"))
 		assert.Equal(t, int(-10), v)
 
-		p.Set("0xf")
+		p.UnmarshalText([]byte("0xf"))
 		assert.Equal(t, int(15), v)
 	}
 }
@@ -78,10 +78,10 @@ func TestNewUint(t *testing.T) {
 	var v uint
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("10")
+		p.UnmarshalText([]byte("10"))
 		assert.Equal(t, uint(10), v)
 
-		p.Set("0xf")
+		p.UnmarshalText([]byte("0xf"))
 		assert.Equal(t, uint(15), v)
 	}
 }
@@ -90,10 +90,10 @@ func TestNewInt8(t *testing.T) {
 	var v int8
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("-10")
+		p.UnmarshalText([]byte("-10"))
 		assert.Equal(t, int8(-10), v)
 
-		p.Set("0xf")
+		p.UnmarshalText([]byte("0xf"))
 		assert.Equal(t, int8(15), v)
 	}
 }
@@ -102,10 +102,10 @@ func TestNewUint8(t *testing.T) {
 	var v uint8
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("10")
+		p.UnmarshalText([]byte("10"))
 		assert.Equal(t, uint8(10), v)
 
-		p.Set("0xf")
+		p.UnmarshalText([]byte("0xf"))
 		assert.Equal(t, uint8(15), v)
 	}
 }
@@ -114,10 +114,10 @@ func TestNewInt16(t *testing.T) {
 	var v int16
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("-10")
+		p.UnmarshalText([]byte("-10"))
 		assert.Equal(t, int16(-10), v)
 
-		p.Set("0xf")
+		p.UnmarshalText([]byte("0xf"))
 		assert.Equal(t, int16(15), v)
 	}
 }
@@ -126,10 +126,10 @@ func TestNewUint16(t *testing.T) {
 	var v uint16
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("10")
+		p.UnmarshalText([]byte("10"))
 		assert.Equal(t, uint16(10), v)
 
-		p.Set("0xf")
+		p.UnmarshalText([]byte("0xf"))
 		assert.Equal(t, uint16(15), v)
 	}
 }
@@ -138,10 +138,10 @@ func TestNewInt32(t *testing.T) {
 	var v int32
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("-10")
+		p.UnmarshalText([]byte("-10"))
 		assert.Equal(t, int32(-10), v)
 
-		p.Set("0xf")
+		p.UnmarshalText([]byte("0xf"))
 		assert.Equal(t, int32(15), v)
 	}
 }
@@ -150,10 +150,10 @@ func TestNewUint32(t *testing.T) {
 	var v uint32
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("10")
+		p.UnmarshalText([]byte("10"))
 		assert.Equal(t, uint32(10), v)
 
-		p.Set("0xf")
+		p.UnmarshalText([]byte("0xf"))
 		assert.Equal(t, uint32(15), v)
 	}
 }
@@ -162,10 +162,10 @@ func TestNewInt64(t *testing.T) {
 	var v int64
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("-10")
+		p.UnmarshalText([]byte("-10"))
 		assert.Equal(t, int64(-10), v)
 
-		p.Set("0xf")
+		p.UnmarshalText([]byte("0xf"))
 		assert.Equal(t, int64(15), v)
 	}
 }
@@ -174,10 +174,10 @@ func TestNewUint64(t *testing.T) {
 	var v uint64
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("10")
+		p.UnmarshalText([]byte("10"))
 		assert.Equal(t, uint64(10), v)
 
-		p.Set("0xf")
+		p.UnmarshalText([]byte("0xf"))
 		assert.Equal(t, uint64(15), v)
 	}
 }
@@ -186,7 +186,7 @@ func TestNewFloat32(t *testing.T) {
 	var v float32
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("-2.5")
+		p.UnmarshalText([]byte("-2.5"))
 		assert.Equal(t, float32(-2.5), v)
 	}
 }
@@ -195,7 +195,7 @@ func TestNewFloat64(t *testing.T) {
 	var v float64
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("-2.5")
+		p.UnmarshalText([]byte("-2.5"))
 		assert.Equal(t, float64(-2.5), v)
 	}
 }
@@ -204,7 +204,7 @@ func TestNewString(t *testing.T) {
 	var v string
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("foo")
+		p.UnmarshalText([]byte("foo"))
 		assert.Equal(t, "foo", v)
 	}
 }
@@ -218,7 +218,7 @@ func TestNewCustomParam(t *testing.T) {
 
 type customParam struct{}
 
-func (p customParam) Set(_ string) error { return nil }
+func (p customParam) UnmarshalText(_ []byte) error { return nil }
 
 func TestNewBoolSlice(t *testing.T) {
 	// A slice of bools is quite useless, yes. But is should work nevertheless.
@@ -228,8 +228,8 @@ func TestNewBoolSlice(t *testing.T) {
 	var v []bool
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("")
-		p.Set("")
+		p.UnmarshalText([]byte(""))
+		p.UnmarshalText([]byte(""))
 		assert.Equal(t, []bool{true, true}, v)
 	}
 }
@@ -238,8 +238,8 @@ func TestNewStringSlice(t *testing.T) {
 	var v []string
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("foo")
-		p.Set("bar")
+		p.UnmarshalText([]byte("foo"))
+		p.UnmarshalText([]byte("bar"))
 		assert.Equal(t, []string{"foo", "bar"}, v)
 	}
 }
@@ -248,8 +248,8 @@ func TestNewStringSliceWithExistingValues(t *testing.T) {
 	v := []string{"x", "y", "z"}
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("foo")
-		p.Set("bar")
+		p.UnmarshalText([]byte("foo"))
+		p.UnmarshalText([]byte("bar"))
 		assert.Equal(t, []string{"x", "y", "z", "foo", "bar"}, v)
 	}
 }
@@ -258,8 +258,8 @@ func TestNewCustomParamSlice(t *testing.T) {
 	var v []customParam
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("foo")
-		p.Set("bar")
+		p.UnmarshalText([]byte("foo"))
+		p.UnmarshalText([]byte("bar"))
 		assert.Equal(t, []customParam{{}, {}}, v)
 	}
 }
@@ -268,7 +268,7 @@ func TestNewStringPointer(t *testing.T) {
 	var v *string
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("foo")
+		p.UnmarshalText([]byte("foo"))
 
 		foo := "foo"
 		assert.Equal(t, &foo, v)
@@ -279,7 +279,7 @@ func TestNewCustomParamPointer(t *testing.T) {
 	var v *customParam
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		p.Set("foo")
+		p.UnmarshalText([]byte("foo"))
 		assert.Equal(t, &customParam{}, v)
 	}
 }
@@ -288,7 +288,7 @@ func TestSetBadValue(t *testing.T) {
 	var v int8
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		err := p.Set("foo").Error()
+		err := p.UnmarshalText([]byte("foo")).Error()
 		assert.Equal(t, "strconv.ParseInt: parsing \"foo\": invalid syntax", err)
 	}
 }
@@ -297,7 +297,7 @@ func TestSetBadValueSlice(t *testing.T) {
 	var v []int8
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		err := p.Set("foo").Error()
+		err := p.UnmarshalText([]byte("foo")).Error()
 		assert.Equal(t, "strconv.ParseInt: parsing \"foo\": invalid syntax", err)
 	}
 }
@@ -306,7 +306,7 @@ func TestSetBadValuePtr(t *testing.T) {
 	var v *int8
 	p, err := param.New(&v)
 	if assert.NoError(t, err) {
-		err := p.Set("foo").Error()
+		err := p.UnmarshalText([]byte("foo")).Error()
 		assert.Equal(t, "strconv.ParseInt: parsing \"foo\": invalid syntax", err)
 	}
 }


### PR DESCRIPTION
This PR removes the public `Param` interface in favor of using the standard library `TextUnmarshaler` interface from the `encoding` package.

To this end, this PR also:

* Removes the entire `param` package into `internal`.
* Removes documentation that discusses `Param`, and updates these to refer to `TextUnmarshaler` instead.
* Adds an example of using an existing `TextUnmarshaler` implementation, namely `net.IP`.
* Adds an example of using a custom `TextUnmarshaler` implementation.
* Briefly discusses possible options users have in terms of off-the-shelf types that can use that implement `TextUnmarshaler`, and why `cli` does not package these directly like `github.com/segmentio/cli` does.