### PR TITLE
Add GitHub action for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: "1.14"
+      - run: go vet ./...
+      - run: go test ./...


### PR DESCRIPTION
This PR adds CI via a GitHub action that `go test`s and `go vet`s every push.